### PR TITLE
Avoid compare_exhange_weak in linear_page.rs

### DIFF
--- a/src/linear_page.rs
+++ b/src/linear_page.rs
@@ -29,7 +29,7 @@ impl<T> LinearPage<T> {
             let new = Box::into_raw(Box::new(LinearPage::<T>::new(init)));
             match self
                 .next
-                .compare_exchange_weak(current, new, Ordering::SeqCst, Ordering::Relaxed)
+                .compare_exchange(current, new, Ordering::SeqCst, Ordering::Relaxed)
             {
                 Ok(_) => {
                     current = new;


### PR DESCRIPTION
compare_exchange_weak can fail spuriously (ie, even if the values match) on some platforms (in my case arm musl). This leads to a panic as we are assuming that x is not null, but in fact it can be null in the spurious failure case. We can wrap this in a loop and check for this, or we can just use the strong variant as I have here, and let llvm do the loop for us.